### PR TITLE
Adding a serviceaccountlib template for centralized chart-library use

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,3 +13,7 @@ template-ingress +ARGS='':
 template-service +ARGS='':
   helm dependency update charts/serviceexample
   helm template charts/serviceexample {{ARGS}}
+
+template-serviceaccount +ARGS='':
+  helm dependency update charts/serviceaccountexample
+  helm template charts/serviceaccountexample {{ARGS}}

--- a/charts/serviceaccountexample/.helmignore
+++ b/charts/serviceaccountexample/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/serviceaccountexample/Chart.yaml
+++ b/charts/serviceaccountexample/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: serviceaccountexample
+description: A Helm chart for Kubernetes service account
+type: application
+version: 0.1.11
+appVersion: "latest"
+dependencies:
+- name: serviceaccountlib
+  version: "*"
+  repository: "file://../../charts/serviceaccountlib"

--- a/charts/serviceaccountexample/templates/serviceaccount.yaml
+++ b/charts/serviceaccountexample/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "serviceaccountlib.serviceaccount" . }}

--- a/charts/serviceaccountexample/values-staging.yaml
+++ b/charts/serviceaccountexample/values-staging.yaml
@@ -1,0 +1,7 @@
+env:
+  CAPE_ROLE: STAGING
+
+serviceAccount:
+  create: true
+  name: serviceaccountexample
+  annotations: {eks.amazonaws.com/role-arn: arn:aws:iam::976748715263:role/service-account-example}

--- a/charts/serviceaccountexample/values.yaml
+++ b/charts/serviceaccountexample/values.yaml
@@ -1,0 +1,16 @@
+image: busybox
+imagePullPolicy: Never
+
+port: 8000
+
+command: "printenv"
+
+limitCpu: 100m
+limitMemory: 256Mi
+
+livenessProbe:
+  path: /livez
+  initialDelaySeconds: 10
+
+readinessProbe:
+  path: /readyz

--- a/charts/serviceaccountlib/.helmignore
+++ b/charts/serviceaccountlib/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/serviceaccountlib/Chart.yaml
+++ b/charts/serviceaccountlib/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: serviceaccountlib
+description: A Helm chart library for role based service account
+type: library
+version: 0.1.4
+appVersion: "1.16.0"

--- a/charts/serviceaccountlib/templates/_serviceaccount.tpl
+++ b/charts/serviceaccountlib/templates/_serviceaccount.tpl
@@ -1,4 +1,4 @@
-{{- define "serviceaccountlib.webapp" -}}
+{{- define "serviceaccountlib.serviceaccount" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/serviceaccountlib/templates/_webapp.tpl
+++ b/charts/serviceaccountlib/templates/_webapp.tpl
@@ -1,0 +1,12 @@
+{{- define "serviceaccountlib.webapp" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
This is a reusable serviceaccountlib template that defines service account using annotations in values.yaml files in repos where this template is used.