### PR TITLE
Edge case handled for when values yaml to be used is unspecified

### DIFF
--- a/charts/serviceaccountlib/templates/_serviceaccount.tpl
+++ b/charts/serviceaccountlib/templates/_serviceaccount.tpl
@@ -5,8 +5,10 @@ metadata:
   name: {{ .Chart.Name }}
   labels:
     app: {{ .Chart.Name }}
+  {{ if .Values.serviceAccount }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When "-f values-staging.yaml" is not used as argument, the serviceaccount template was getting a nil error because it was finding annotations in wrong values file.