### PR TITLE
Set a revision history limit to stop limit repliasets

### DIFF
--- a/charts/deploymentlib/templates/_webapp.tpl
+++ b/charts/deploymentlib/templates/_webapp.tpl
@@ -15,6 +15,7 @@ spec:
       labels:
         app: {{ .Chart.Name }}
     spec:
+      revisionHistoryLimit: 3
       {{- if .Values.serviceAccount }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}


### PR DESCRIPTION
Each deployment creates a new replica set if someone wants to rollback. This will limit the number of replicasets we store