### PR TITLE
remove namespace from sealed secret

### DIFF
--- a/charts/deploymentexample/output.staging.yaml
+++ b/charts/deploymentexample/output.staging.yaml
@@ -126,7 +126,6 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   name: sealed-image-pull-secret
-  namesapce: default
   labels:
     name: sealed-image-pull-secret
     app: deploymentexample
@@ -139,7 +138,6 @@ spec:
     data: null
     metadata:
       name: sealed-image-pull-secret
-      namesapce: default
       labels:
         name: sealed-image-pull-secret
         app: deploymentexample

--- a/charts/podlib/Chart.yaml
+++ b/charts/podlib/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: podlib
 description: A Helm chart library for Kubernetes pods
 type: library
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.16.0"

--- a/charts/podlib/templates/_sealedsecret.tpl
+++ b/charts/podlib/templates/_sealedsecret.tpl
@@ -26,7 +26,6 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   name: sealed-image-pull-secret
-  namesapce: {{ .Release.Namespace }}
   labels:
     name: sealed-image-pull-secret
     app: {{ .Chart.Name }}
@@ -39,14 +38,12 @@ spec:
     data: null
     metadata:
       name: sealed-image-pull-secret
-      namesapce: {{ .Release.Namespace }}
       labels:
         name: sealed-image-pull-secret
         app: {{ .Chart.Name }}
         repo: {{ .Values.labels.repo }}
         version: {{ .Chart.Version }}
     type: kubernetes.io/dockerconfigjson
-
 ---
 {{- end -}}
 


### PR DESCRIPTION
having the namespace in the manifest causes argocd to go out of sync 

![image](https://user-images.githubusercontent.com/46675621/133981085-19ffddc8-0913-4c0e-b61c-f0d6b4b8feb8.png)
