### PR TITLE
Adding revisionHistoryLimit to deployment template

### DIFF
--- a/charts/asimmetric/templates/deployment.yaml
+++ b/charts/asimmetric/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
   selector:
     matchLabels:
       {{- include "asimmetric.selectorLabels" (dict "context" $ "name" $name) | nindent 6 }}
+  revisionHistoryLimit: {{ default 3 $data.revisionHistoryLimit }}
   template:
     metadata:
       labels:

--- a/examples/asimmetric-example/output-local.yaml
+++ b/examples/asimmetric-example/output-local.yaml
@@ -40,6 +40,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: example-service
       app.kubernetes.io/instance: asimmetric-example
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/examples/asimmetric-example/output-staging.yaml
+++ b/examples/asimmetric-example/output-staging.yaml
@@ -97,6 +97,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: example-service
       app.kubernetes.io/instance: asimmetric-example
+  revisionHistoryLimit: 4
   template:
     metadata:
       labels:
@@ -231,6 +232,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: example-worker
       app.kubernetes.io/instance: asimmetric-example
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/examples/asimmetric-example/values-staging.yaml
+++ b/examples/asimmetric-example/values-staging.yaml
@@ -24,6 +24,7 @@ asimmetric:
   applications:
     example-service:
       role: webapp
+      revisionHistoryLimit: 4
       replicaCount: 2
       image:
         tag: example-service-tag

--- a/examples/asimmetric-example/values.example.yaml
+++ b/examples/asimmetric-example/values.example.yaml
@@ -71,6 +71,10 @@ asimmetric:
       ## Sets the replica count (Optional)
       ## Default: 1
       ##
+      revisionHistoryLimit: 3
+      ## Sets number of old ReplicaSets for this deployment to be retained
+      ## Default: 3
+      ##
       replicaCount: 1
       ## Configures the image and image pull policy (Optional)
       ## Default: uses .global.image
@@ -214,6 +218,10 @@ asimmetric:
       role: worker
       ## Sets the replica count (Optional)
       ## Default: 1
+      ##
+      revisionHistoryLimit: 3
+      ## Sets number of old ReplicaSets for this deployment to be retained
+      ## Default: 3
       ##
       replicaCount: 1
       ## Configures the image and image pull policy (Optional)


### PR DESCRIPTION
`spec.revisionHistoryLimit` added in deployment to retain only specified number of old ReplicaSets